### PR TITLE
Integer coordinate functions

### DIFF
--- a/src/dense.rs
+++ b/src/dense.rs
@@ -36,16 +36,32 @@ impl<'a> DenseNode<'a> {
 
     /// Returns the latitude coordinate in degrees.
     pub fn lat(&self) -> f64 {
-        0.000_000_001_f64 * (self.block.get_lat_offset() +
-                             (i64::from(self.block.get_granularity()) *
-                              self.lat)) as f64
+        1e-9 * self.nano_lat() as f64
+    }
+
+    /// Returns the latitude coordinate in nanodegrees (10⁻⁹).
+    pub fn nano_lat(&self) -> i64 {
+        self.block.get_lat_offset() + i64::from(self.block.get_granularity()) * self.lat
+    }
+
+    /// Returns the latitude coordinate in decimicrodegrees (10⁻⁷).
+    pub fn decimicro_lat(&self) -> i32 {
+        (self.nano_lat() / 100) as i32
     }
 
     /// Returns the longitude coordinate in degrees.
     pub fn lon(&self) -> f64 {
-        0.000_000_001_f64 * (self.block.get_lon_offset() +
-                             (i64::from(self.block.get_granularity()) *
-                              self.lon)) as f64
+        1e-9 * self.nano_lon() as f64
+    }
+
+    /// Returns the longitude in nanodegrees (10⁻⁹).
+    pub fn nano_lon(&self) -> i64 {
+        self.block.get_lon_offset() + i64::from(self.block.get_granularity()) * self.lon
+    }
+
+    /// Returns the longitude coordinate in decimicrodegrees (10⁻⁷).
+    pub fn decimicro_lon(&self) -> i32 {
+        (self.nano_lon() / 100) as i32
     }
 
     /// Returns the time stamp in milliseconds since the epoch.

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -85,16 +85,32 @@ impl<'a> Node<'a> {
 
     /// Returns the latitude coordinate in degrees.
     pub fn lat(&self) -> f64 {
-        0.000_000_001_f64 * (self.block.get_lat_offset() +
-                             (i64::from(self.block.get_granularity()) *
-                              self.osmnode.get_lat())) as f64
+        1e-9 * self.nano_lat() as f64
+    }
+
+    /// Returns the latitude coordinate in nanodegrees (10⁻⁹).
+    pub fn nano_lat(&self) -> i64 {
+        self.block.get_lat_offset() + i64::from(self.block.get_granularity()) * self.osmnode.get_lat()
+    }
+
+    /// Returns the latitude coordinate in decimicrodegrees (10⁻⁷).
+    pub fn decimicro_lat(&self) -> i32 {
+        (self.nano_lat() / 100) as i32
     }
 
     /// Returns the longitude coordinate in degrees.
     pub fn lon(&self) -> f64 {
-        0.000_000_001_f64 * (self.block.get_lon_offset() +
-                             (i64::from(self.block.get_granularity()) *
-                              self.osmnode.get_lon())) as f64
+        1e-9 * self.nano_lon() as f64
+    }
+
+    /// Returns the longitude in nanodegrees (10⁻⁹).
+    pub fn nano_lon(&self) -> i64 {
+        self.block.get_lon_offset() + i64::from(self.block.get_granularity()) * self.osmnode.get_lon()
+    }
+
+    /// Returns the longitude coordinate in decimicrodegrees (10⁻⁷).
+    pub fn decimicro_lon(&self) -> i32 {
+        (self.nano_lon() / 100) as i32
     }
 
     /// Returns an iterator over the tags of this node

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -46,7 +46,6 @@ fn check_primitive_block_content(block: &PrimitiveBlock) {
         assert_eq!(nodes[2].nano_lon(), 11631019200);
         assert_eq!(nodes[2].decimicro_lon(), 116310192);
 
-
         assert_eq!(nodes[0].id(), 105);
         assert_eq!(nodes[1].id(), 106);
         assert_eq!(nodes[2].id(), 108);

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -28,11 +28,24 @@ fn check_primitive_block_content(block: &PrimitiveBlock) {
     if !nodes.is_empty() {
         assert_eq!(nodes.len(), 3);
 
+        // node 1 lat
         assert!(approx_eq(nodes[1].lat(), 52.11992359584));
+        assert_eq!(nodes[1].nano_lat(), 52119923500);
+        assert_eq!(nodes[1].decimicro_lat(), 521199235);
+        // node 1 lon
         assert!(approx_eq(nodes[1].lon(), 11.62564468943));
+        assert_eq!(nodes[1].nano_lon(), 11625644600);
+        assert_eq!(nodes[1].decimicro_lon(), 116256446);
 
+        // node 2 lat
         assert!(approx_eq(nodes[2].lat(), 52.11989910567));
+        assert_eq!(nodes[2].nano_lat(), 52119899100);
+        assert_eq!(nodes[2].decimicro_lat(), 521198991);
+        //node 2 lon
         assert!(approx_eq(nodes[2].lon(), 11.63101926915));
+        assert_eq!(nodes[2].nano_lon(), 11631019200);
+        assert_eq!(nodes[2].decimicro_lon(), 116310192);
+
 
         assert_eq!(nodes[0].id(), 105);
         assert_eq!(nodes[1].id(), 106);
@@ -47,11 +60,23 @@ fn check_primitive_block_content(block: &PrimitiveBlock) {
     if !dense_nodes.is_empty() {
         assert_eq!(dense_nodes.len(), 3);
 
+        // node 1 lat
         assert!(approx_eq(dense_nodes[1].lat(), 52.11992359584));
+        assert_eq!(dense_nodes[1].nano_lat(), 52119923500);
+        assert_eq!(dense_nodes[1].decimicro_lat(), 521199235);
+        //node 1 lon
         assert!(approx_eq(dense_nodes[1].lon(), 11.62564468943));
+        assert_eq!(dense_nodes[1].nano_lon(), 11625644600);
+        assert_eq!(dense_nodes[1].decimicro_lon(), 116256446);
 
+        //node 2 lat
         assert!(approx_eq(dense_nodes[2].lat(), 52.11989910567));
+        assert_eq!(dense_nodes[2].nano_lat(), 52119899100);
+        assert_eq!(dense_nodes[2].decimicro_lat(), 521198991);
+        // node 2 lon
         assert!(approx_eq(dense_nodes[2].lon(), 11.63101926915));
+        assert_eq!(dense_nodes[2].nano_lon(), 11631019200);
+        assert_eq!(dense_nodes[2].decimicro_lon(), 116310192);
 
         assert_eq!(dense_nodes[0].id, 105);
         assert_eq!(dense_nodes[1].id, 106);


### PR DESCRIPTION
This adds `nano_lat/lon` and `decimicro_lat/lon` methods to `Node` and `DenseNode` for those situations where the cast to a floating point number is unnecessary.