### PR TITLE
changes to be non-buffering

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -152,14 +152,14 @@ impl BlobHeader {
 
 /// A reader for PBF files that allows iterating over `Blob`s.
 #[derive(Clone, Debug)]
-pub struct BlobReader<R: Read> {
+pub struct BlobReader<R: Read + Send> {
     reader: R,
     /// Current reader offset in bytes from the start of the stream.
     offset: Option<ByteOffset>,
     last_blob_ok: bool,
 }
 
-impl<R: Read> BlobReader<R> {
+impl<R: Read + Send> BlobReader<R> {
     /// Creates a new `BlobReader`.
     ///
     /// # Example
@@ -258,7 +258,7 @@ impl BlobReader<BufReader<File>> {
     }
 }
 
-impl<R: Read> Iterator for BlobReader<R> {
+impl<R: Read + Send> Iterator for BlobReader<R> {
     type Item = Result<Blob>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -294,7 +294,7 @@ impl<R: Read> Iterator for BlobReader<R> {
     }
 }
 
-impl<R: Read + Seek> BlobReader<R> {
+impl<R: Read + Seek + Send> BlobReader<R> {
     /// Creates a new `BlobReader` from the given reader that is seekable and will be initialized
     /// with a valid offset.
     ///

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -38,12 +38,12 @@ struct BlobInfo {
 /// Allows filtering elements and iterating over their dependencies.
 /// It chooses an efficient method for navigating the PBF structure to achieve this in reasonable
 /// time and with reasonable memory.
-pub struct IndexedReader<R: Read + Seek> {
+pub struct IndexedReader<R: Read + Seek + Send> {
     reader: BlobReader<R>,
     index: Vec<BlobInfo>,
 }
 
-impl<R: Read + Seek> IndexedReader<R> {
+impl<R: Read + Seek + Send> IndexedReader<R> {
     /// Creates a new `IndexedReader`.
     ///
     /// # Example


### PR DESCRIPTION
With these changes (elaborated in #3), I can process planet.osm.pbf (40+GB) and begin receiving results right away while using much less memory than before. I tried to keep this minimal, but I did need to add `Send` to the traits so that `par_bridge()` would work for the `par_map_reduce()` method.

I think a bigger change which I mentioned in #3 already would be to have `.iter()` and `.par_iter()` methods with the relevant decoding logic attached so that you could use any iteration methods which the std or rayon defines, but this patch is designed to be minimal and only fixes the existing methods so that they will work on large files without buffering into memory.