### PR TITLE
Add deleted() function to info

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -552,4 +552,9 @@ impl<'a> Info<'a> {
             true
         }
     }
+
+    /// Returns the deleted status of an element.
+    pub fn deleted(&self) -> bool {
+        !self.visible()
+    }
 }


### PR DESCRIPTION
Deleted elements are somewhat unintuitively specified as those not visible,
so this simple wrapper avoids a lot of googling and going through the libosmium
code that I had to do to discover this.