### PR TITLE
Ran cargo fmt to simplify contrib diffs

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -354,12 +354,10 @@ impl<R: Read + Seek + Send> BlobReader<R> {
     pub fn blob_from_offset(&mut self, pos: ByteOffset) -> Result<Blob> {
         self.seek(pos)?;
         self.next().unwrap_or_else(|| {
-            Err(new_error(ErrorKind::Io(
-                ::std::io::Error::new(
-                    ::std::io::ErrorKind::UnexpectedEof,
-                    "no blob at this stream position",
-                )
-            )))
+            Err(new_error(ErrorKind::Io(::std::io::Error::new(
+                ::std::io::ErrorKind::UnexpectedEof,
+                "no blob at this stream position",
+            ))))
         })
     }
 
@@ -504,7 +502,6 @@ where
         Err(new_blob_error(BlobError::Empty))
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -285,12 +285,14 @@ impl<'a> Iterator for DenseNodeInfoIter<'a> {
             self.duser_sids.next(),
             self.visible.next(),
         ) {
-            (Some(&version),
-             Some(dtimestamp),
-             Some(dchangeset),
-             Some(duid),
-             Some(duser_sid),
-             visible_opt) => {
+            (
+                Some(&version),
+                Some(dtimestamp),
+                Some(dchangeset),
+                Some(duid),
+                Some(duser_sid),
+                visible_opt,
+            ) => {
                 self.ctimestamp += *dtimestamp;
                 self.cchangeset += *dchangeset;
                 self.cuid += *duid;

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,7 +58,6 @@ pub enum ErrorKind {
     StringtableIndexOutOfBounds { index: usize },
     /// An error that occurs when decoding `Blob`s.
     Blob(BlobError),
-
     //TODO add UnexpectedPrimitiveBlock
 }
 

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -56,8 +56,10 @@ impl BlobInfo {
     /// Is there at least one node in this blob?
     fn nodes_available(&self) -> ElementsAvailable {
         match self.id_ranges {
-            Some(IdRanges {node_ids: Some(_), ..}) => ElementsAvailable::Yes,
-            Some(IdRanges {node_ids: None, ..}) => ElementsAvailable::No,
+            Some(IdRanges {
+                node_ids: Some(_), ..
+            }) => ElementsAvailable::Yes,
+            Some(IdRanges { node_ids: None, .. }) => ElementsAvailable::No,
             None => ElementsAvailable::Unknown,
         }
     }
@@ -65,8 +67,10 @@ impl BlobInfo {
     /// Is there at least one way in this blob?
     fn ways_available(&self) -> ElementsAvailable {
         match self.id_ranges {
-            Some(IdRanges {way_ids: Some(_), ..}) => ElementsAvailable::Yes,
-            Some(IdRanges {way_ids: None, ..}) => ElementsAvailable::No,
+            Some(IdRanges {
+                way_ids: Some(_), ..
+            }) => ElementsAvailable::Yes,
+            Some(IdRanges { way_ids: None, .. }) => ElementsAvailable::No,
             None => ElementsAvailable::Unknown,
         }
     }
@@ -88,13 +92,16 @@ impl BlobInfo {
         match self.id_ranges.as_ref() {
             None => RangeIncluded::Unknown,
             Some(IdRanges { node_ids: None, .. }) => RangeIncluded::No,
-            Some(IdRanges { node_ids: Some(range), .. }) => {
+            Some(IdRanges {
+                node_ids: Some(range),
+                ..
+            }) => {
                 if range_included(range.clone(), node_ids) {
                     RangeIncluded::Yes(range.clone())
                 } else {
                     RangeIncluded::No
                 }
-            },
+            }
         }
     }
 }
@@ -267,8 +274,13 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
         //   * Filter ways and store their dependencies as node IDs
         for info in &mut self.index {
             //TODO do something useful with header blocks
-            if info.blob_type == SimpleBlobType::Primitive && info.ways_available() != ElementsAvailable::No {
-                let block = self.reader.blob_from_offset(info.offset)?.to_primitiveblock()?;
+            if info.blob_type == SimpleBlobType::Primitive
+                && info.ways_available() != ElementsAvailable::No
+            {
+                let block = self
+                    .reader
+                    .blob_from_offset(info.offset)?
+                    .to_primitiveblock()?;
                 Self::update_element_id_ranges(info, &block);
 
                 for group in block.groups() {
@@ -293,7 +305,10 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
             if let RangeIncluded::Yes(node_id_range) = info.node_range_included(&node_ids) {
                 //TODO Only collect into Vec if range has a reasonable size
                 let node_ids: Vec<i64> = node_ids.range(node_id_range).copied().collect();
-                let block = self.reader.blob_from_offset(info.offset)?.to_primitiveblock()?;
+                let block = self
+                    .reader
+                    .blob_from_offset(info.offset)?
+                    .to_primitiveblock()?;
                 for group in block.groups() {
                     for node in group.nodes() {
                         if node_ids.binary_search(&node.id()).is_ok() {
@@ -354,8 +369,13 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
 
         for info in &mut self.index {
             // Skip header blobs and blobs where there are certainly no nodes available.
-            if info.blob_type == SimpleBlobType::Primitive && info.nodes_available() != ElementsAvailable::No {
-                let block = self.reader.blob_from_offset(info.offset)?.to_primitiveblock()?;
+            if info.blob_type == SimpleBlobType::Primitive
+                && info.nodes_available() != ElementsAvailable::No
+            {
+                let block = self
+                    .reader
+                    .blob_from_offset(info.offset)?
+                    .to_primitiveblock()?;
                 Self::update_element_id_ranges(info, &block);
 
                 for group in block.groups() {

--- a/src/proto/fileformat.proto
+++ b/src/proto/fileformat.proto
@@ -65,5 +65,3 @@ message BlobHeader {
   optional bytes indexdata = 2;
   required int32 datasize = 3;
 }
-
-

--- a/src/proto/osmformat.proto
+++ b/src/proto/osmformat.proto
@@ -260,4 +260,3 @@ message Relation {
   repeated sint64 memids = 9 [packed = true]; // DELTA encoded
   repeated MemberType types = 10 [packed = true];
 }
-

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -127,10 +127,9 @@ impl<R: Read + Send> ElementReader<R> {
             .par_bridge()
             .map(|blob| match blob?.decode() {
                 Ok(BlobDecode::OsmHeader(_)) | Ok(BlobDecode::Unknown(_)) => Ok(identity()),
-                Ok(BlobDecode::OsmData(block)) => Ok(block
-                    .elements()
-                    .map(&map_op)
-                    .fold(identity(), &reduce_op)),
+                Ok(BlobDecode::OsmData(block)) => {
+                    Ok(block.elements().map(&map_op).fold(identity(), &reduce_op))
+                }
                 Err(e) => Err(e),
             })
             .reduce(

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -19,9 +19,9 @@ fn approx_eq(a: f64, b: f64) -> bool {
 // Compare the content of a HeaderBlock with known values from the test file.
 fn check_header_block_content(block: &HeaderBlock) {
     for feature in block.required_features() {
-        if feature != "OsmSchema-V0.6" &&
-           feature != "DenseNodes" &&
-           feature != "HistoricalInformation"
+        if feature != "OsmSchema-V0.6"
+            && feature != "DenseNodes"
+            && feature != "HistoricalInformation"
         {
             panic!("unknown required feature: {}", feature);
         }
@@ -258,7 +258,10 @@ fn read_history_file() {
     check_header_block_content(&header);
 
     let primitive_block = blobs[1].to_primitiveblock().unwrap();
-    let nodes: Vec<_> = primitive_block.groups().flat_map(|g| g.dense_nodes()).collect();
+    let nodes: Vec<_> = primitive_block
+        .groups()
+        .flat_map(|g| g.dense_nodes())
+        .collect();
 
     assert_eq!(nodes.len(), 2);
 


### PR DESCRIPTION
This makes code less likely to have extra diffs when contributing from mulitple people.
Unless you want to customize it with https://github.com/rust-lang/rustfmt/blob/master/Configurations.md ?

I think it would be good to add `cargo fmt` and `cargo clippy` tests to the CI to keep the code "standardized" (whatever that really means?)