### PR TITLE
Make clippy happy, spelling, cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 target
 Cargo.lock
 .*.swp

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -198,14 +198,14 @@ impl<R: Read + Send> BlobReader<R> {
             }
             Err(e) => {
                 self.offset = None;
-                match e.kind() {
+                return match e.kind() {
                     ::std::io::ErrorKind::UnexpectedEof => {
                         //TODO This also accepts corrupted files in the case of 1-3 available bytes
-                        return None;
+                        None
                     }
                     _ => {
                         self.last_blob_ok = false;
-                        return Some(Err(new_blob_error(BlobError::InvalidHeaderSize)));
+                        Some(Err(new_blob_error(BlobError::InvalidHeaderSize)))
                     }
                 }
             }
@@ -500,7 +500,7 @@ mod tests {
             let ff_blob = fileformat::Blob::new();
 
             let blob = Blob::new(ff_header, ff_blob, None);
-            assert!(blob.get_type() == *blob_type);
+            assert_eq!(blob.get_type(), *blob_type);
         }
     }
 }

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -27,7 +27,7 @@ impl<'a> DenseNode<'a> {
         self.id
     }
 
-    /// return optional metadata about the ndode
+    /// return optional metadata about the node
     pub fn info(&'a self) -> Option<&'a DenseNodeInfo<'a>> {
         self.info.as_ref()
     }

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -423,20 +423,20 @@ mod tests {
         let mut set = BTreeSet::<i64>::new();
         set.extend(&[1, 2, 6]);
 
-        assert_eq!(range_included(RangeInclusive::new(0, 0), &set), false);
-        assert_eq!(range_included(RangeInclusive::new(1, 1), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(2, 2), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(3, 3), &set), false);
-        assert_eq!(range_included(RangeInclusive::new(3, 5), &set), false);
-        assert_eq!(range_included(RangeInclusive::new(3, 6), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(6, 6), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(7, 7), &set), false);
-        assert_eq!(range_included(RangeInclusive::new(0, 1), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(6, 7), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(2, 3), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(5, 6), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(5, 8), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(0, 8), &set), true);
-        assert_eq!(range_included(RangeInclusive::new(0, 4), &set), true);
+        assert!(!range_included(RangeInclusive::new(0, 0), &set));
+        assert!(range_included(RangeInclusive::new(1, 1), &set));
+        assert!(range_included(RangeInclusive::new(2, 2), &set));
+        assert!(!range_included(RangeInclusive::new(3, 3), &set));
+        assert!(!range_included(RangeInclusive::new(3, 5), &set));
+        assert!(range_included(RangeInclusive::new(3, 6), &set));
+        assert!(range_included(RangeInclusive::new(6, 6), &set));
+        assert!(!range_included(RangeInclusive::new(7, 7), &set));
+        assert!(range_included(RangeInclusive::new(0, 1), &set));
+        assert!(range_included(RangeInclusive::new(6, 7), &set));
+        assert!(range_included(RangeInclusive::new(2, 3), &set));
+        assert!(range_included(RangeInclusive::new(5, 6), &set));
+        assert!(range_included(RangeInclusive::new(5, 8), &set));
+        assert!(range_included(RangeInclusive::new(0, 8), &set));
+        assert!(range_included(RangeInclusive::new(0, 4), &set));
     }
 }

--- a/src/proto/osmformat.proto
+++ b/src/proto/osmformat.proto
@@ -194,9 +194,9 @@ message Node {
   required sint64 lon = 9;
 }
 
-/* Used to densly represent a sequence of nodes that do not have any tags.
+/* Used to densely represent a sequence of nodes that do not have any tags.
 
-We represent these nodes columnwise as five columns: ID's, lats, and
+We represent these nodes column-wise as five columns: ID's, lats, and
 lons, all delta coded. When metadata is not omitted,
 
 We encode keys & vals for all nodes as a single array of integers

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -81,8 +81,8 @@ fn is_same_unordered(a: &[&str], b: &[String]) -> bool {
     if a.len() == b.len() {
         let mut a = a.to_vec();
         let mut b = b.to_vec();
-        a.sort();
-        b.sort();
+        a.sort_unstable();
+        b.sort_unstable();
         a.iter().zip(b.iter()).filter(|&(a, b)| a == b).count() == a.len()
     } else {
         false
@@ -139,9 +139,9 @@ fn check_primitive_block_content(block: &PrimitiveBlock) {
         assert_eq!(nodes[1].info().uid(), Some(17));
         assert_eq!(nodes[2].info().uid(), Some(17));
 
-        assert_eq!(nodes[0].info().visible(), true);
-        assert_eq!(nodes[1].info().visible(), true);
-        assert_eq!(nodes[2].info().visible(), true);
+        assert!(nodes[0].info().visible());
+        assert!(nodes[1].info().visible());
+        assert!(nodes[2].info().visible());
     }
 
     let dense_nodes = block.t_dense_nodes();
@@ -192,9 +192,7 @@ fn check_primitive_block_content(block: &PrimitiveBlock) {
 
         let way_refs: Vec<_> = ways[0].refs().collect();
         assert_eq!(way_refs, [105, 106, 108, 105]);
-
-        let nodes: Vec<_> = ways[0].node_locations().collect();
-        assert_eq!(nodes.len(), 0);
+        assert_eq!(ways[0].node_locations().count(), 0);
     }
 
     {
@@ -222,7 +220,7 @@ fn read_blobs() {
         assert_eq!(blobs[1].get_type(), BlobType::OsmData);
 
         let header = blobs[0].to_headerblock().unwrap();
-        check_header_block_content(&header, &test_file);
+        check_header_block_content(&header, test_file);
 
         let primitive_block = blobs[1].to_primitiveblock().unwrap();
         check_primitive_block_content(&primitive_block);
@@ -242,7 +240,7 @@ fn read_mmap_blobs() {
         assert_eq!(blobs[1].get_type(), BlobType::OsmData);
 
         if let BlobDecode::OsmHeader(header) = blobs[0].decode().unwrap() {
-            check_header_block_content(&header, &test_file);
+            check_header_block_content(&header, test_file);
         } else {
             panic!("Unexpected blob type");
         }
@@ -309,11 +307,7 @@ fn read_ways_and_deps() {
 
         reader
             .read_ways_and_deps(
-                |way| {
-                    way.tags()
-                        .find(|&key_value| key_value == ("building", "yes"))
-                        .is_some()
-                },
+                |way| way.tags().any(|key_value| key_value == ("building", "yes")),
                 |element| {
                     match element {
                         Element::Way(_) => ways += 1,
@@ -347,8 +341,8 @@ fn read_history_file() {
 
     assert_eq!(nodes.len(), 2);
 
-    assert_eq!(nodes[0].info().unwrap().visible(), false);
-    assert_eq!(nodes[1].info().unwrap().visible(), true);
+    assert!(!nodes[0].info().unwrap().visible());
+    assert!(nodes[1].info().unwrap().visible());
 }
 
 #[test]


### PR DESCRIPTION
* Address all fmt and clippy concerns, simplifying the code a bit in the process
* a few spelling corrections
* simplify asserts