### PR TITLE
Migrate to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ A reader for the OpenStreetMap PBF file format (*.osm.pbf).
 categories = ["parser-implementations", "encoding", "science"]
 keywords = ["openstreetmap", "osm", "pbf", "protocolbuffer", "protobuf"]
 license = "MIT/Apache-2.0"
-edition = "2021"
+edition = "2018"
 
 [features]
 default = ["system-libz"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ A reader for the OpenStreetMap PBF file format (*.osm.pbf).
 categories = ["parser-implementations", "encoding", "science"]
 keywords = ["openstreetmap", "osm", "pbf", "protocolbuffer", "protobuf"]
 license = "MIT/Apache-2.0"
+edition = "2021"
 
 [features]
 default = ["system-libz"]

--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ Add this to your `Cargo.toml`:
 osmpbf = "0.2"
 ```
 
-and if you're using Rust 2015, add this line to the crate root:
-
-```rust
-extern crate osmpbf;
-```
-
 Here's a simple example that counts all the ways in a file:
 
 ```rust

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -1,8 +1,6 @@
 // Count the number of nodes, ways and relations in a PBF file given as the
 // first command line argument.
 
-extern crate osmpbf;
-
 use osmpbf::*;
 
 fn main() {

--- a/examples/indexed.rs
+++ b/examples/indexed.rs
@@ -1,8 +1,6 @@
 // Count the number of buildings and their nodes from a PBF file
 // given as the first command line argument.
 
-extern crate osmpbf;
-
 use osmpbf::{Element, IndexedReader};
 use std::error::Error;
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -3,14 +3,14 @@
 extern crate byteorder;
 extern crate protobuf;
 
-use block::{HeaderBlock, PrimitiveBlock};
+use crate::block::{HeaderBlock, PrimitiveBlock};
+use crate::error::{new_blob_error, new_error, new_protobuf_error, BlobError, ErrorKind, Result};
+use crate::proto::fileformat;
+use crate::util::{parse_message_from_bytes, parse_message_from_reader};
 use byteorder::ReadBytesExt;
-use error::{new_blob_error, new_error, new_protobuf_error, BlobError, ErrorKind, Result};
-use proto::fileformat;
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
-use util::{parse_message_from_bytes, parse_message_from_reader};
 
 #[cfg(feature = "system-libz")]
 use flate2::read::ZlibDecoder;

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,8 +1,5 @@
 //! Read and decode blobs
 
-extern crate byteorder;
-extern crate protobuf;
-
 use crate::block::{HeaderBlock, PrimitiveBlock};
 use crate::error::{new_blob_error, new_error, new_protobuf_error, BlobError, ErrorKind, Result};
 use crate::proto::fileformat;

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,9 +1,9 @@
 //! `HeaderBlock`, `PrimitiveBlock` and `PrimitiveGroup`s
 
-use dense::DenseNodeIter;
-use elements::{Element, Node, Relation, Way};
-use error::{new_error, ErrorKind, Result};
-use proto::osmformat;
+use crate::dense::DenseNodeIter;
+use crate::elements::{Element, Node, Relation, Way};
+use crate::error::{new_error, ErrorKind, Result};
+use crate::proto::osmformat;
 use std;
 
 /// A `HeaderBlock`. It contains metadata about following [`PrimitiveBlock`]s.

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -1,8 +1,8 @@
 //! Iterate over the dense nodes in a `PrimitiveGroup`
 
-use block::str_from_stringtable;
-use error::Result;
-use proto::osmformat;
+use crate::block::str_from_stringtable;
+use crate::error::Result;
+use crate::proto::osmformat;
 use std;
 
 //TODO Add getter functions for id, version, uid, ...

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,10 +1,10 @@
 //! Nodes, ways and relations
 
-use block::str_from_stringtable;
-use dense::DenseNode;
-use error::Result;
-use proto::osmformat;
-use proto::osmformat::PrimitiveBlock;
+use crate::block::str_from_stringtable;
+use crate::dense::DenseNode;
+use crate::error::Result;
+use crate::proto::osmformat;
+use crate::proto::osmformat::PrimitiveBlock;
 
 /// An enum with the OSM core elements: nodes, ways and relations.
 #[derive(Clone, Debug)]

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -1,12 +1,12 @@
 //! Speed up searches by using an index
 
-use error::Result;
+use crate::error::Result;
+use crate::{BlobReader, BlobType, ByteOffset, Element, PrimitiveBlock, Way};
 use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::{Read, Seek};
 use std::ops::RangeInclusive;
 use std::path::Path;
-use {BlobReader, BlobType, ByteOffset, Element, PrimitiveBlock, Way};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SimpleBlobType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ osmpbf = "0.2"
 and if you're using Rust 2015, add this line to the crate root:
 
 ```rust
-extern crate osmpbf;
 ```
 
 ## Example: Count ways
@@ -68,17 +67,6 @@ println!("Number of ways: {}", ways);
 */
 
 #![recursion_limit = "1024"]
-
-extern crate byteorder;
-extern crate memmap;
-extern crate protobuf;
-extern crate rayon;
-
-#[cfg(feature = "system-libz")]
-extern crate flate2;
-
-#[cfg(not(feature = "system-libz"))]
-extern crate inflate;
 
 pub use blob::*;
 pub use block::*;

--- a/src/mmap_blob.rs
+++ b/src/mmap_blob.rs
@@ -1,9 +1,5 @@
 //! Iterate over blobs from a memory map
 
-extern crate byteorder;
-extern crate memmap;
-extern crate protobuf;
-
 use self::fileformat::BlobHeader;
 use crate::blob::{decode_blob, BlobDecode, BlobType, ByteOffset};
 use crate::block::{HeaderBlock, PrimitiveBlock};

--- a/src/mmap_blob.rs
+++ b/src/mmap_blob.rs
@@ -5,14 +5,15 @@ extern crate memmap;
 extern crate protobuf;
 
 use self::fileformat::BlobHeader;
-use blob::{decode_blob, BlobDecode, BlobType, ByteOffset};
-use block::{HeaderBlock, PrimitiveBlock};
+use crate::blob::{decode_blob, BlobDecode, BlobType, ByteOffset};
+use crate::block::{HeaderBlock, PrimitiveBlock};
+use crate::error::{new_blob_error, new_protobuf_error, BlobError, Result};
+use crate::proto::{fileformat, osmformat};
+use crate::util::parse_message_from_bytes;
+use crate::MAX_BLOB_HEADER_SIZE;
 use byteorder::ByteOrder;
-use error::{new_blob_error, new_protobuf_error, BlobError, Result};
-use proto::{fileformat, osmformat};
 use std::fs::File;
 use std::path::Path;
-use util::parse_message_from_bytes;
 
 /// A read-only memory map.
 #[derive(Debug)]
@@ -198,7 +199,7 @@ impl<'a> Iterator for MmapBlobReader<'a> {
 
         let header_size = byteorder::BigEndian::read_u32(slice) as usize;
 
-        if header_size as u64 >= ::blob::MAX_BLOB_HEADER_SIZE {
+        if header_size as u64 >= MAX_BLOB_HEADER_SIZE {
             self.last_blob_ok = false;
             return Some(Err(new_blob_error(BlobError::HeaderTooBig {
                 size: header_size as u64,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,8 +1,8 @@
 //! High level reader interface
 
-use blob::{BlobDecode, BlobReader};
-use elements::Element;
-use error::Result;
+use crate::blob::{BlobDecode, BlobReader};
+use crate::elements::Element;
+use crate::error::Result;
 use rayon::prelude::*;
 use std::fs::File;
 use std::io::{BufReader, Read};

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,6 +1,3 @@
-extern crate assert_approx_eq;
-extern crate osmpbf;
-
 use assert_approx_eq::assert_approx_eq;
 use osmpbf::*;
 


### PR DESCRIPTION
Long overdue migration to the 2018 edition (that's what causes most of the changes, 2021 was much more benign, but has some issues so postponing until another PR)