### PR TITLE
Migrate to protobuf v3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ environment:
       target: x86_64-pc-windows-msvc
     - channel: stable
       target: i686-pc-windows-msvc
-    - channel: 1.58.0
+    - channel: 1.60.0
       target: x86_64-pc-windows-msvc
 
 install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ byteorder = "1.4"
 flate2 = { version = "1.0", optional = true }
 inflate = "0.4"
 memmap = "0.7"
-protobuf = "2.27"
+protobuf = "3.1"
 rayon = "1.5"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 
 [build-dependencies]
-protobuf-codegen-pure = "2"
+protobuf-codegen = "3.1"

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let out_dir = std::env::var("OUT_DIR")?;
 
-    protobuf_codegen_pure::Codegen::new()
+    protobuf_codegen::Codegen::new()
+        .pure()
         .out_dir(&out_dir)
         .inputs(&proto_files)
         .include("src/proto")

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -39,7 +39,7 @@ impl<'a> DenseNode<'a> {
 
     /// Returns the latitude coordinate in nanodegrees (10⁻⁹).
     pub fn nano_lat(&self) -> i64 {
-        self.block.get_lat_offset() + i64::from(self.block.get_granularity()) * self.lat
+        self.block.lat_offset() + i64::from(self.block.granularity()) * self.lat
     }
 
     /// Returns the latitude coordinate in decimicrodegrees (10⁻⁷).
@@ -54,7 +54,7 @@ impl<'a> DenseNode<'a> {
 
     /// Returns the longitude in nanodegrees (10⁻⁹).
     pub fn nano_lon(&self) -> i64 {
-        self.block.get_lon_offset() + i64::from(self.block.get_granularity()) * self.lon
+        self.block.lon_offset() + i64::from(self.block.granularity()) * self.lon
     }
 
     /// Returns the longitude coordinate in decimicrodegrees (10⁻⁷).
@@ -101,16 +101,19 @@ impl<'a> DenseNodeIter<'a> {
         block: &'a osmformat::PrimitiveBlock,
         osmdense: &'a osmformat::DenseNodes,
     ) -> DenseNodeIter<'a> {
-        let info_iter = Some(DenseNodeInfoIter::new(block, osmdense.get_denseinfo()));
+        let info_iter = Some(DenseNodeInfoIter::new(
+            block,
+            osmdense.denseinfo.get_or_default(),
+        ));
         DenseNodeIter {
             block,
-            dids: osmdense.get_id().iter(),
+            dids: osmdense.id.iter(),
             cid: 0,
-            dlats: osmdense.get_lat().iter(),
+            dlats: osmdense.lat.iter(),
             clat: 0,
-            dlons: osmdense.get_lon().iter(),
+            dlons: osmdense.lon.iter(),
             clon: 0,
-            keys_vals_slice: osmdense.get_keys_vals(),
+            keys_vals_slice: osmdense.keys_vals.as_slice(),
             keys_vals_index: 0,
             info_iter,
         }
@@ -220,7 +223,7 @@ impl<'a> DenseNodeInfo<'a> {
 
     /// Returns the time stamp in milliseconds since the epoch.
     pub fn milli_timestamp(&self) -> i64 {
-        self.timestamp * i64::from(self.block.get_date_granularity())
+        self.timestamp * i64::from(self.block.date_granularity())
     }
 
     /// Returns the visibility status of an element. This is only relevant if the PBF file contains
@@ -259,16 +262,16 @@ impl<'a> DenseNodeInfoIter<'a> {
     ) -> DenseNodeInfoIter<'a> {
         DenseNodeInfoIter {
             block,
-            versions: info.get_version().iter(),
-            dtimestamps: info.get_timestamp().iter(),
+            versions: info.version.iter(),
+            dtimestamps: info.timestamp.iter(),
             ctimestamp: 0,
-            dchangesets: info.get_changeset().iter(),
+            dchangesets: info.changeset.iter(),
             cchangeset: 0,
-            duids: info.get_uid().iter(),
+            duids: info.uid.iter(),
             cuid: 0,
-            duser_sids: info.get_user_sid().iter(),
+            duser_sids: info.user_sid.iter(),
             cuser_sid: 0,
-            visible: info.get_visible().iter(),
+            visible: info.visible.iter(),
         }
     }
 }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -5,6 +5,8 @@ use crate::dense::DenseNode;
 use crate::error::Result;
 use crate::proto::osmformat;
 use crate::proto::osmformat::PrimitiveBlock;
+use osmformat::relation::MemberType;
+use protobuf::EnumOrUnknown;
 
 /// An enum with the OSM core elements: nodes, ways and relations.
 #[derive(Clone, Debug)]
@@ -39,7 +41,7 @@ impl<'a> Node<'a> {
     /// Returns the node id. It should be unique between nodes and might be negative to indicate
     /// that the element has not yet been uploaded to a server.
     pub fn id(&self) -> i64 {
-        self.osmnode.get_id()
+        self.osmnode.id()
     }
 
     /// Returns an iterator over the tags of this node
@@ -68,14 +70,14 @@ impl<'a> Node<'a> {
     pub fn tags(&self) -> TagIter<'a> {
         TagIter {
             block: self.block,
-            key_indices: self.osmnode.get_keys().iter(),
-            val_indices: self.osmnode.get_vals().iter(),
+            key_indices: self.osmnode.keys.iter(),
+            val_indices: self.osmnode.vals.iter(),
         }
     }
 
     /// Returns additional metadata for this element.
     pub fn info(&self) -> Info<'a> {
-        Info::new(self.block, self.osmnode.get_info())
+        Info::new(self.block, self.osmnode.info.get_or_default())
     }
 
     /// Returns the latitude coordinate in degrees.
@@ -85,8 +87,7 @@ impl<'a> Node<'a> {
 
     /// Returns the latitude coordinate in nanodegrees (10⁻⁹).
     pub fn nano_lat(&self) -> i64 {
-        self.block.get_lat_offset()
-            + i64::from(self.block.get_granularity()) * self.osmnode.get_lat()
+        self.block.lat_offset() + i64::from(self.block.granularity()) * self.osmnode.lat()
     }
 
     /// Returns the latitude coordinate in decimicrodegrees (10⁻⁷).
@@ -101,8 +102,7 @@ impl<'a> Node<'a> {
 
     /// Returns the longitude in nanodegrees (10⁻⁹).
     pub fn nano_lon(&self) -> i64 {
-        self.block.get_lon_offset()
-            + i64::from(self.block.get_granularity()) * self.osmnode.get_lon()
+        self.block.lon_offset() + i64::from(self.block.granularity()) * self.osmnode.lon()
     }
 
     /// Returns the longitude coordinate in decimicrodegrees (10⁻⁷).
@@ -116,8 +116,8 @@ impl<'a> Node<'a> {
     /// [`PrimitiveBlock`](crate::block::PrimitiveBlock).
     pub fn raw_tags(&self) -> RawTagIter<'a> {
         RawTagIter {
-            key_indices: self.osmnode.get_keys().iter(),
-            val_indices: self.osmnode.get_vals().iter(),
+            key_indices: self.osmnode.keys.iter(),
+            val_indices: self.osmnode.vals.iter(),
         }
     }
 
@@ -126,7 +126,7 @@ impl<'a> Node<'a> {
     /// contained strings are UTF-8 encoded but it is not safe to assume that (use
     /// `std::str::from_utf8`).
     pub fn raw_stringtable(&self) -> &[Vec<u8>] {
-        self.block.get_stringtable().get_s()
+        self.block.stringtable.s.as_slice()
     }
 }
 
@@ -147,7 +147,7 @@ impl<'a> Way<'a> {
 
     /// Returns the way id.
     pub fn id(&self) -> i64 {
-        self.osmway.get_id()
+        self.osmway.id()
     }
 
     /// Returns an iterator over the tags of this way
@@ -176,14 +176,14 @@ impl<'a> Way<'a> {
     pub fn tags(&self) -> TagIter<'a> {
         TagIter {
             block: self.block,
-            key_indices: self.osmway.get_keys().iter(),
-            val_indices: self.osmway.get_vals().iter(),
+            key_indices: self.osmway.keys.iter(),
+            val_indices: self.osmway.vals.iter(),
         }
     }
 
     /// Returns additional metadata for this element.
     pub fn info(&self) -> Info<'a> {
-        Info::new(self.block, self.osmway.get_info())
+        Info::new(self.block, self.osmway.info.get_or_default())
     }
 
     /// Returns an iterator over the references of this way. Each reference should correspond to a
@@ -193,7 +193,7 @@ impl<'a> Way<'a> {
     /// (to save space) ways themselves usually do not contain geo coordinates.
     pub fn refs(&self) -> WayRefIter<'a> {
         WayRefIter {
-            deltas: self.osmway.get_refs().iter(),
+            deltas: self.osmway.refs.iter(),
             current: 0,
         }
     }
@@ -208,8 +208,8 @@ impl<'a> Way<'a> {
     pub fn node_locations(&self) -> WayNodeLocationsIter<'a> {
         WayNodeLocationsIter {
             block: self.block,
-            dlats: self.osmway.get_lat().iter(),
-            dlons: self.osmway.get_lon().iter(),
+            dlats: self.osmway.lat.iter(),
+            dlons: self.osmway.lon.iter(),
             clat: 0,
             clon: 0,
         }
@@ -217,7 +217,7 @@ impl<'a> Way<'a> {
 
     /// Returns a slice of delta coded node ids.
     pub fn raw_refs(&self) -> &[i64] {
-        self.osmway.get_refs()
+        self.osmway.refs.as_slice()
     }
 
     /// Returns an iterator over the tags of this way
@@ -226,8 +226,8 @@ impl<'a> Way<'a> {
     /// [`PrimitiveBlock`](crate::block::PrimitiveBlock).
     pub fn raw_tags(&self) -> RawTagIter<'a> {
         RawTagIter {
-            key_indices: self.osmway.get_keys().iter(),
-            val_indices: self.osmway.get_vals().iter(),
+            key_indices: self.osmway.keys.iter(),
+            val_indices: self.osmway.vals.iter(),
         }
     }
 
@@ -236,7 +236,7 @@ impl<'a> Way<'a> {
     /// contained strings are UTF-8 encoded but it is not safe to assume that (use
     /// `std::str::from_utf8`).
     pub fn raw_stringtable(&self) -> &[Vec<u8>] {
-        self.block.get_stringtable().get_s()
+        self.block.stringtable.s.as_slice()
     }
 }
 
@@ -256,7 +256,7 @@ impl<'a> Relation<'a> {
 
     /// Returns the relation id.
     pub fn id(&self) -> i64 {
-        self.osmrel.get_id()
+        self.osmrel.id()
     }
 
     /// Returns an iterator over the tags of this relation
@@ -285,14 +285,14 @@ impl<'a> Relation<'a> {
     pub fn tags(&self) -> TagIter<'a> {
         TagIter {
             block: self.block,
-            key_indices: self.osmrel.get_keys().iter(),
-            val_indices: self.osmrel.get_vals().iter(),
+            key_indices: self.osmrel.keys.iter(),
+            val_indices: self.osmrel.vals.iter(),
         }
     }
 
     /// Returns additional metadata for this element.
     pub fn info(&self) -> Info<'a> {
-        Info::new(self.block, self.osmrel.get_info())
+        Info::new(self.block, self.osmrel.info.get_or_default())
     }
 
     /// Returns an iterator over the members of this relation.
@@ -306,8 +306,8 @@ impl<'a> Relation<'a> {
     /// [`PrimitiveBlock`](crate::block::PrimitiveBlock).
     pub fn raw_tags(&self) -> RawTagIter<'a> {
         RawTagIter {
-            key_indices: self.osmrel.get_keys().iter(),
-            val_indices: self.osmrel.get_vals().iter(),
+            key_indices: self.osmrel.keys.iter(),
+            val_indices: self.osmrel.vals.iter(),
         }
     }
 
@@ -316,7 +316,7 @@ impl<'a> Relation<'a> {
     /// contained strings are UTF-8 encoded but it is not safe to assume that (use
     /// `std::str::from_utf8`).
     pub fn raw_stringtable(&self) -> &[Vec<u8>] {
-        self.block.get_stringtable().get_s()
+        self.block.stringtable.s.as_slice()
     }
 }
 
@@ -407,10 +407,8 @@ impl<'a> Iterator for WayNodeLocationsIter<'a> {
                 self.clat += dlat;
                 self.clon += dlon;
                 Some(WayNodeLocation {
-                    lat: self.block.get_lat_offset()
-                        + i64::from(self.block.get_granularity()) * self.clat,
-                    lon: self.block.get_lon_offset()
-                        + i64::from(self.block.get_granularity()) * self.clon,
+                    lat: self.block.lat_offset() + i64::from(self.block.granularity()) * self.clat,
+                    lon: self.block.lon_offset() + i64::from(self.block.granularity()) * self.clon,
                 })
             }
             _ => None,
@@ -432,12 +430,12 @@ pub enum RelMemberType {
     Relation,
 }
 
-impl From<osmformat::Relation_MemberType> for RelMemberType {
-    fn from(rmt: osmformat::Relation_MemberType) -> RelMemberType {
-        match rmt {
-            osmformat::Relation_MemberType::NODE => RelMemberType::Node,
-            osmformat::Relation_MemberType::WAY => RelMemberType::Way,
-            osmformat::Relation_MemberType::RELATION => RelMemberType::Relation,
+impl From<EnumOrUnknown<MemberType>> for RelMemberType {
+    fn from(rmt: EnumOrUnknown<MemberType>) -> RelMemberType {
+        match rmt.unwrap() {
+            MemberType::NODE => RelMemberType::Node,
+            MemberType::WAY => RelMemberType::Way,
+            MemberType::RELATION => RelMemberType::Relation,
         }
     }
 }
@@ -467,7 +465,7 @@ pub struct RelMemberIter<'a> {
     block: &'a PrimitiveBlock,
     role_sids: std::slice::Iter<'a, i32>,
     member_id_deltas: std::slice::Iter<'a, i64>,
-    member_types: std::slice::Iter<'a, osmformat::Relation_MemberType>,
+    member_types: std::slice::Iter<'a, EnumOrUnknown<MemberType>>,
     current_member_id: i64,
 }
 
@@ -475,9 +473,9 @@ impl<'a> RelMemberIter<'a> {
     fn new(block: &'a PrimitiveBlock, osmrel: &'a osmformat::Relation) -> RelMemberIter<'a> {
         RelMemberIter {
             block,
-            role_sids: osmrel.get_roles_sid().iter(),
-            member_id_deltas: osmrel.get_memids().iter(),
-            member_types: osmrel.get_types().iter(),
+            role_sids: osmrel.roles_sid.iter(),
+            member_id_deltas: osmrel.memids.iter(),
+            member_types: osmrel.types.iter(),
             current_member_id: 0,
         }
     }
@@ -579,17 +577,13 @@ impl<'a> Info<'a> {
 
     /// Returns the version of this element.
     pub fn version(&self) -> Option<i32> {
-        if self.info.has_version() {
-            Some(self.info.get_version())
-        } else {
-            None
-        }
+        self.info.version
     }
 
     /// Returns the time stamp in milliseconds since the epoch.
     pub fn milli_timestamp(&self) -> Option<i64> {
         if self.info.has_timestamp() {
-            Some(self.info.get_timestamp() * i64::from(self.block.get_date_granularity()))
+            Some(self.info.timestamp() * i64::from(self.block.date_granularity()))
         } else {
             None
         }
@@ -597,20 +591,12 @@ impl<'a> Info<'a> {
 
     /// Returns the changeset id.
     pub fn changeset(&self) -> Option<i64> {
-        if self.info.has_changeset() {
-            Some(self.info.get_changeset())
-        } else {
-            None
-        }
+        self.info.changeset
     }
 
     /// Returns the user id.
     pub fn uid(&self) -> Option<i32> {
-        if self.info.has_uid() {
-            Some(self.info.get_uid())
-        } else {
-            None
-        }
+        self.info.uid
     }
 
     /// Returns the user name.
@@ -618,7 +604,7 @@ impl<'a> Info<'a> {
         if self.info.has_user_sid() {
             Some(str_from_stringtable(
                 self.block,
-                self.info.get_user_sid() as usize,
+                self.info.user_sid() as usize,
             ))
         } else {
             None
@@ -628,11 +614,10 @@ impl<'a> Info<'a> {
     /// Returns the visibility status of an element. This is only relevant if the PBF file contains
     /// historical information.
     pub fn visible(&self) -> bool {
-        if self.info.has_visible() {
-            self.info.get_visible()
-        } else {
+        match self.info.visible {
+            Some(v) => v,
             // If the visible flag is not present it must be assumed to be true.
-            true
+            None => true,
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::result;
 use std::str;
 use std::str::Utf8Error;
 
-use protobuf::ProtobufError;
+use protobuf::Error as ProtobufError;
 
 // Error data structures are modeled just like in the `csv` crate by BurntSushi.
 

--- a/src/mmap_blob.rs
+++ b/src/mmap_blob.rs
@@ -88,9 +88,9 @@ impl<'a> MmapBlob<'a> {
     /// Decodes the blob and tries to obtain the inner content (usually a [`HeaderBlock`] or a
     /// [`PrimitiveBlock`]). This operation might involve an expensive decompression step.
     pub fn decode(&'a self) -> Result<BlobDecode<'a>> {
-        let blob: fileformat::Blob = Message::parse_from_bytes(self.data)
+        let blob = fileformat::Blob::parse_from_bytes(self.data)
             .map_err(|e| new_protobuf_error(e, "blob content"))?;
-        match self.header.get_field_type() {
+        match self.header.type_() {
             "OSMHeader" => {
                 let block = Box::new(HeaderBlock::new(decode_blob(&blob)?));
                 Ok(BlobDecode::OsmHeader(block))
@@ -105,7 +105,7 @@ impl<'a> MmapBlob<'a> {
 
     /// Returns the type of a blob without decoding its content.
     pub fn get_type(&self) -> BlobType {
-        match self.header.get_field_type() {
+        match self.header.type_() {
             "OSMHeader" => BlobType::OsmHeader,
             "OSMData" => BlobType::OsmData,
             x => BlobType::Unknown(x),
@@ -211,7 +211,7 @@ impl<'a> Iterator for MmapBlobReader<'a> {
             return Some(Err(io_error.into()));
         }
 
-        let header: BlobHeader = match Message::parse_from_bytes(&slice[4..(4 + header_size)]) {
+        let header = match BlobHeader::parse_from_bytes(&slice[4..(4 + header_size)]) {
             Ok(x) => x,
             Err(e) => {
                 self.last_blob_ok = false;
@@ -219,7 +219,7 @@ impl<'a> Iterator for MmapBlobReader<'a> {
             }
         };
 
-        let data_size = header.get_datasize() as usize;
+        let data_size = header.datasize() as usize;
         let chunk_size = 4 + header_size + data_size;
 
         if slice.len() < chunk_size {


### PR DESCRIPTION
Migrate to the v3 of the protobuf crate, and a few minor cleanups.

MSRV is now 1.60.0 due to protobuf lib requirements