### PR TITLE
Use named args in format (requires 1.58)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ environment:
       target: x86_64-pc-windows-msvc
     - channel: stable
       target: i686-pc-windows-msvc
-    - channel: 1.52.1
+    - channel: 1.58.0
       target: x86_64-pc-windows-msvc
 
 install:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ reader.for_each(|element| {
     }
 })?;
 
-println!("Number of ways: {}", ways);
+println!("Number of ways: {ways}");
 ```
 
 In this second example, we also count the ways but make use of all cores by
@@ -57,7 +57,7 @@ let ways = reader.par_map_reduce(
     |a, b| a + b   // Sum the partial results
 )?;
 
-println!("Number of ways: {}", ways);
+println!("Number of ways: {ways}");
 ```
 
 ## The PBF format

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proto_files = ["src/proto/fileformat.proto", "src/proto/osmformat.proto"];
 
     for path in &proto_files {
-        println!("cargo:rerun-if-changed={}", path);
+        println!("cargo:rerun-if-changed={path}");
     }
 
     let out_dir = std::env::var("OUT_DIR")?;

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -22,12 +22,12 @@ fn main() {
         |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
     ) {
         Ok((nodes, ways, relations)) => {
-            println!("Nodes: {}", nodes);
-            println!("Ways: {}", ways);
-            println!("Relations: {}", relations);
+            println!("Nodes: {nodes}");
+            println!("Ways: {ways}");
+            println!("Relations: {relations}");
         }
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
         }
     }
 }

--- a/examples/indexed.rs
+++ b/examples/indexed.rs
@@ -32,6 +32,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     )?;
 
     // Print result
-    println!("ways:  {}\nnodes: {}", ways, nodes);
+    println!("ways:  {ways}\nnodes: {nodes}");
     Ok(())
 }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -56,7 +56,7 @@ impl<'a> Node<'a> {
     /// reader.for_each(|element| {
     ///     if let Element::Node(node) = element {
     ///         for (key, value) in node.tags() {
-    ///             println!("key: {}, value: {}", key, value);
+    ///             println!("key: {key}, value: {value}");
     ///         }
     ///     }
     /// })?;
@@ -164,7 +164,7 @@ impl<'a> Way<'a> {
     /// reader.for_each(|element| {
     ///     if let Element::Way(way) = element {
     ///         for (key, value) in way.tags() {
-    ///             println!("key: {}, value: {}", key, value);
+    ///             println!("key: {key}, value: {value}");
     ///         }
     ///     }
     /// })?;
@@ -273,7 +273,7 @@ impl<'a> Relation<'a> {
     /// reader.for_each(|element| {
     ///     if let Element::Relation(relation) = element {
     ///         for (key, value) in relation.tags() {
-    ///             println!("key: {}, value: {}", key, value);
+    ///             println!("key: {key}, value: {value}");
     ///         }
     ///     }
     /// })?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -151,22 +151,22 @@ impl fmt::Display for Error {
         match *self.0 {
             ErrorKind::Io(ref err) => err.fmt(f),
             ErrorKind::Protobuf { ref err, location } => {
-                write!(f, "protobuf error at '{}': {}", location, err)
+                write!(f, "protobuf error at '{location}': {err}")
             }
             ErrorKind::StringtableUtf8 { ref err, index } => {
-                write!(f, "invalid UTF-8 at string table index {}: {}", index, err)
+                write!(f, "invalid UTF-8 at string table index {index}: {err}")
             }
             ErrorKind::StringtableIndexOutOfBounds { index } => {
-                write!(f, "stringtable index out of bounds: {}", index)
+                write!(f, "stringtable index out of bounds: {index}")
             }
             ErrorKind::Blob(BlobError::InvalidHeaderSize) => {
                 write!(f, "blob header size could not be decoded")
             }
             ErrorKind::Blob(BlobError::HeaderTooBig { size }) => {
-                write!(f, "blob header is too big: {} bytes", size)
+                write!(f, "blob header is too big: {size} bytes")
             }
             ErrorKind::Blob(BlobError::MessageTooBig { size }) => {
-                write!(f, "blob message is too big: {} bytes", size)
+                write!(f, "blob message is too big: {size} bytes")
             }
             ErrorKind::Blob(BlobError::Empty) => {
                 write!(f, "blob is missing fields 'raw' and 'zlib_data'")

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -253,7 +253,7 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
     ///     },
     /// )?;
     ///
-    /// println!("ways:  {}\nnodes: {}", ways, nodes);
+    /// println!("ways:  {ways}\nnodes: {nodes}");
     ///
     /// # assert_eq!(ways, 1);
     /// # assert_eq!(nodes, 3);
@@ -354,7 +354,7 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
     ///     },
     /// )?;
     ///
-    /// println!("nodes: {}", nodes);
+    /// println!("nodes: {nodes}");
     ///
     /// # assert_eq!(nodes, 3);
     /// # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ reader.for_each(|element| {
     }
 })?;
 
-println!("Number of ways: {}", ways);
+println!("Number of ways: {ways}");
 # assert_eq!(ways, 1);
 # Ok::<(), std::io::Error>(())
 ```
@@ -55,7 +55,7 @@ let ways = reader.par_map_reduce(
     |a, b| a + b   // Sum the partial results
 )?;
 
-println!("Number of ways: {}", ways);
+println!("Number of ways: {ways}");
 # assert_eq!(ways, 1);
 # Ok::<(), std::io::Error>(())
 ```

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -58,7 +58,7 @@ impl<R: Read + Send> ElementReader<R> {
     ///     }
     /// })?;
     ///
-    /// println!("Number of ways: {}", ways);
+    /// println!("Number of ways: {ways}");
     ///
     /// # Ok(())
     /// # }
@@ -111,7 +111,7 @@ impl<R: Read + Send> ElementReader<R> {
     ///     |a, b| a + b   // Sum the partial results
     /// )?;
     ///
-    /// println!("Number of ways: {}", ways);
+    /// println!("Number of ways: {ways}");
     /// # Ok(())
     /// # }
     /// # foo().unwrap();

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -90,15 +90,13 @@ fn check_header_block_content(block: &HeaderBlock, test_file: &TestFile) {
     let res = block.required_features();
     assert!(
         is_same_unordered(test_file.req, res),
-        "Required features {:?} don't match expected {:?}",
-        res,
+        "Required features {res:?} don't match expected {:?}",
         test_file.req
     );
     let res = block.optional_features();
     assert!(
         is_same_unordered(test_file.opt, res),
-        "Optional features {:?} don't match expected {:?}",
-        res,
+        "Optional features {res:?} don't match expected {:?}",
         test_file.opt
     );
 }


### PR DESCRIPTION
See https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html

This was added as part of the https://github.com/rust-lang/rust/releases/tag/1.58.0