### PR TITLE
a few minor cleanups for Cargo.toml, 2021 ed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,16 +2,13 @@
 name = "osmpbf"
 version = "0.2.8"
 authors = ["Johannes Hofmann <mail@b-r-u.org>"]
-readme = "README.md"
 repository = "https://github.com/b-r-u/osmpbf"
 homepage = "https://github.com/b-r-u/osmpbf"
-description = """
-A reader for the OpenStreetMap PBF file format (*.osm.pbf).
-"""
+description = "A reader for the OpenStreetMap PBF file format (*.osm.pbf)."
 categories = ["parser-implementations", "encoding", "science"]
 keywords = ["openstreetmap", "osm", "pbf", "protocolbuffer", "protobuf"]
-license = "MIT/Apache-2.0"
-edition = "2018"
+license = "MIT OR Apache-2.0"
+edition = "2021"
 
 [features]
 default = ["system-libz"]


### PR DESCRIPTION
Note that readme field is already defaulted to the typical readme.md file