### PR TITLE
Simplify RelMemberType

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -8,6 +8,8 @@ use crate::proto::osmformat::PrimitiveBlock;
 use osmformat::relation::MemberType;
 use protobuf::EnumOrUnknown;
 
+pub use osmformat::relation::MemberType as RelMemberType;
+
 /// An enum with the OSM core elements: nodes, ways and relations.
 #[derive(Clone, Debug)]
 pub enum Element<'a> {
@@ -422,24 +424,6 @@ impl<'a> Iterator for WayNodeLocationsIter<'a> {
 
 impl<'a> ExactSizeIterator for WayNodeLocationsIter<'a> {}
 
-/// The element type of a relation member.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum RelMemberType {
-    Node,
-    Way,
-    Relation,
-}
-
-impl From<EnumOrUnknown<MemberType>> for RelMemberType {
-    fn from(rmt: EnumOrUnknown<MemberType>) -> RelMemberType {
-        match rmt.unwrap() {
-            MemberType::NODE => RelMemberType::Node,
-            MemberType::WAY => RelMemberType::Way,
-            MemberType::RELATION => RelMemberType::Relation,
-        }
-    }
-}
-
 //TODO encapsulate member_id based on member_type (NodeId, WayId, RelationId)
 /// A member of a relation.
 ///
@@ -496,7 +480,7 @@ impl<'a> Iterator for RelMemberIter<'a> {
                     block: self.block,
                     role_sid: *role_sid,
                     member_id: self.current_member_id,
-                    member_type: RelMemberType::from(*member_type),
+                    member_type: member_type.unwrap(),
                 })
             }
             _ => None,

--- a/src/proto/osmformat.proto
+++ b/src/proto/osmformat.proto
@@ -242,9 +242,9 @@ message Way {
 
 message Relation {
   enum MemberType {
-    NODE = 0;
-    WAY = 1;
-    RELATION = 2;
+    Node = 0;
+    Way = 1;
+    Relation = 2;
   }
 
   required int64 id = 1;


### PR DESCRIPTION
This makes the code a bit more performant by removing the wrapping RelMemberType as a separate enum. No point now with protobuf3 as it gets generated as is.

I had to modify the .proto file to make the casing consistent, but eventually I do hope the protobuf lib itself can do that on the fly.

See also https://github.com/stepancheg/rust-protobuf/issues/639