### PR TITLE
Add libz-ng support and benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,15 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [features]
+# Note that both libz and libz-ng can be enabled at the same time.
+# In this case libz will use the ng version internally.
 default = ["system-libz"]
-system-libz = ["flate2"]
+system-libz = ["flate2", "flate2/zlib"]
+system-libz-ng = ["flate2", "flate2/zlib-ng"]
 
 [dependencies]
 byteorder = "1.4"
-flate2 = { version = "1.0", optional = true }
+flate2 = { version = "1.0", default-features = false, optional = true }
 inflate = "0.4"
 memmap = "0.7"
 protobuf = "3.1"
@@ -24,6 +27,11 @@ rayon = "1.5"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
+criterion = { version = "0.3", features = ["html_reports"] }
 
 [build-dependencies]
 protobuf-codegen = "3.1"
+
+[[bench]]
+name = "counter_bench"
+harness = false

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ let ways = reader.par_map_reduce(
 println!("Number of ways: {ways}");
 ```
 
+## Build Features
+* `system-libz` (default) -- use `zlib` system library for decoding
+* `system-libz-ng` -- use `zlib-ng` library for better performance.
+* `default-features = false` -- use a slower Rust-based implementation.
+
 ## The PBF format
 
 To effectively use the more lower-level features of this library it is useful to

--- a/benches/counter_bench.rs
+++ b/benches/counter_bench.rs
@@ -1,0 +1,41 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use osmpbf::{Element, ElementReader};
+use std::env;
+
+criterion_group!(benches, bench_count);
+criterion_main!(benches);
+
+fn bench_count(c: &mut Criterion) {
+    let file = env!(
+        "OSMPBF_BENCH_FILE",
+        "Must specify OSMPBF_BENCH_FILE env var when compiling this benchmark"
+    );
+
+    // Note that both libz and libz-ng can be enabled at the same time.
+    // In this case libz will use the ng version internally.
+
+    #[cfg(feature = "system-libz")]
+    println!("Using ZlibDecoder...");
+    #[cfg(feature = "system-libz-ng")]
+    println!("Using ZstdDecoder with NG...");
+    #[cfg(not(any(feature = "system-libz", feature = "system-libz-ng")))]
+    println!("Using DeflateDecoder...");
+
+    c.bench_function(format!("Benchmarking using {file}").as_str(), |b| {
+        b.iter(|| {
+            let path = std::path::Path::new(file);
+            let reader = ElementReader::from_path(path).unwrap();
+            reader
+                .par_map_reduce(
+                    |element| match element {
+                        Element::Node(_) | Element::DenseNode(_) => (1, 0, 0),
+                        Element::Way(_) => (0, 1, 0),
+                        Element::Relation(_) => (0, 0, 1),
+                    },
+                    || (0u64, 0u64, 0u64),
+                    |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
+                )
+                .unwrap()
+        })
+    });
+}

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -28,6 +28,7 @@ fn main() {
         }
         Err(e) => {
             println!("{e}");
+            std::process::exit(1);
         }
     }
 }


### PR DESCRIPTION
Add support for `system-libz-ng` feature flag. When specified, it will use the faster zlib-ng library - my performance tests shows about 5-8% performance gain.

Also add a simple benchmark that counts various elements in a file. To use, must provide a path to the test osm.pbf file using `OSMPBF_BENCH_FILE` env var (during benchmark compilation)

```
OSMPBF_BENCH_FILE=....../tanzania-latest.osm.pbf cargo bench --features system-libz-ng --no-default-features
```

Lastly, make sure the example exits with a non-zero error if it fails.