### PR TITLE
Change memmap dependency to memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ system-libz = ["flate2"]
 byteorder = "1.4"
 flate2 = { version = "1.0", optional = true }
 inflate = "0.4"
-memmap = "0.7"
+memmap2 = "0.5"
 protobuf = "3.1"
 rayon = "1.5"
 

--- a/src/mmap_blob.rs
+++ b/src/mmap_blob.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 /// A read-only memory map.
 #[derive(Debug)]
 pub struct Mmap {
-    mmap: memmap::Mmap,
+    mmap: memmap2::Mmap,
 }
 
 impl Mmap {
@@ -37,7 +37,7 @@ impl Mmap {
     /// # foo().unwrap();
     /// ```
     pub unsafe fn from_file(file: &File) -> Result<Mmap> {
-        memmap::Mmap::map(file)
+        memmap2::Mmap::map(file)
             .map(|m| Mmap { mmap: m })
             .map_err(|e| e.into())
     }
@@ -61,7 +61,7 @@ impl Mmap {
     /// ```
     pub unsafe fn from_path<P: AsRef<Path>>(path: P) -> Result<Mmap> {
         let file = File::open(&path)?;
-        memmap::Mmap::map(&file)
+        memmap2::Mmap::map(&file)
             .map(|m| Mmap { mmap: m })
             .map_err(|e| e.into())
     }


### PR DESCRIPTION
This crate depends on [memmap](https://crates.io/crates/memmap), which is unmaintained (see https://github.com/danburkert/memmap-rs/issues/90). This PR would change the dependency to [memmap2](https://crates.io/crates/memmap2), a maintained fork of memmap.