### PR TITLE
Async blob reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,12 @@ jobs:
         run: cargo test --verbose --no-default-features --features zlib
       - name: Run tests (with zlib-ng)
         run: cargo test --verbose --no-default-features --features zlib-ng
+      - name: Run tests (with async)
+        run: cargo test --verbose --features async
       - name: Lint
         run: cargo clippy -- -Dwarnings
       - name: Build documentation
-        run: cargo doc --verbose
+        run: cargo doc --verbose --features async
 
   TestMatrix:
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,21 +12,28 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [features]
+async = ["async-stream", "object_store", "tokio", "tokio/io-util", "tokio-stream"]
 default = ["rust-zlib"]
 rust-zlib = ["flate2/rust_backend"]
 zlib = ["flate2/zlib"]
 zlib-ng = ["flate2/zlib-ng"]
 
 [dependencies]
+async-stream = { version = "0.3.6", optional = true }
 byteorder = "1.4"
 flate2 = { version = "1.0", default-features = false }
 memmap2 = "0.5"
+object_store = { version = "0.13", optional = true }
 protobuf = "3.1"
 rayon = "1.5"
+tokio = { version =  "1.49", optional = true }
+tokio-stream = { version = "0.1", optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 criterion = { version = "0.3", features = ["html_reports"] }
+tokio-test = "0.4.5"
+futures-util = "0.3.31"
 
 [build-dependencies]
 protobuf-codegen = "3.1"

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -3,11 +3,17 @@
 use crate::block::{HeaderBlock, PrimitiveBlock};
 use crate::error::{new_blob_error, new_error, new_protobuf_error, BlobError, ErrorKind, Result};
 use crate::proto::fileformat;
+#[cfg(feature = "async")]
+use async_stream::stream;
 use byteorder::ReadBytesExt;
 use protobuf::Message;
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
+#[cfg(feature = "async")]
+use tokio::io::AsyncReadExt;
+#[cfg(feature = "async")]
+use tokio_stream::Stream;
 
 use flate2::read::ZlibDecoder;
 
@@ -449,6 +455,182 @@ impl BlobReader<BufReader<File>> {
         let f = File::open(path.as_ref())?;
         let buf_reader = BufReader::new(f);
         Self::new_seekable(buf_reader)
+    }
+}
+
+#[derive(Debug)]
+#[cfg(feature = "async")]
+/// A reader for PBF files that allows streaming of [`Blob`]s.
+pub struct AsyncBlobReader {
+    reader: object_store::buffered::BufReader,
+    /// Current reader offset in bytes from the start of the stream.
+    offset: Option<ByteOffset>,
+    last_blob_ok: bool,
+}
+
+#[cfg(feature = "async")]
+impl AsyncBlobReader {
+    /// Creates a new `AsyncBlobReader`.
+    ///
+    /// # Example
+    /// ```
+    /// use osmpbf::*;
+    /// use object_store::ObjectStoreExt;
+    ///
+    /// # tokio_test::block_on(async {
+    /// // Setup object store
+    /// let store = object_store::local::LocalFileSystem::new();
+    /// let path = std::path::Path::new("tests/test.osm.pbf");
+    /// let filesystem_path = object_store::path::Path::from_filesystem_path(path).unwrap();
+    /// let object_meta = store.head(&filesystem_path).await.unwrap();
+    ///
+    /// // Setup buf reader
+    /// let buf_reader = object_store::buffered::BufReader::new(std::sync::Arc::new(store), &object_meta);
+    /// let reader = AsyncBlobReader::new(buf_reader);
+    /// # })
+    /// ```
+    pub fn new(reader: object_store::buffered::BufReader) -> AsyncBlobReader {
+        AsyncBlobReader {
+            reader,
+            offset: None,
+            last_blob_ok: true,
+        }
+    }
+
+    async fn read_blob_header(&mut self) -> Option<Result<fileformat::BlobHeader>> {
+        let header_size: u64 = match self.reader.read_u32().await {
+            Ok(n) => {
+                self.offset = self.offset.map(|x| ByteOffset(x.0 + 4));
+                u64::from(n)
+            }
+            Err(e) => {
+                self.offset = None;
+                return match e.kind() {
+                    ::std::io::ErrorKind::UnexpectedEof => None,
+                    _ => {
+                        self.last_blob_ok = false;
+                        Some(Err(new_blob_error(BlobError::InvalidHeaderSize)))
+                    }
+                };
+            }
+        };
+
+        if header_size >= MAX_BLOB_HEADER_SIZE {
+            self.last_blob_ok = false;
+            return Some(Err(new_blob_error(BlobError::HeaderTooBig {
+                size: header_size,
+            })));
+        }
+
+        let mut buffer = vec![0; header_size as usize];
+        let read_result = self.reader.read_exact(&mut buffer).await;
+        match read_result {
+            Ok(read_byte_count) => {
+                if read_byte_count != header_size as usize {
+                    return Some(Err(new_blob_error(BlobError::InvalidHeaderSize)));
+                }
+            }
+            Err(e) => {
+                return Some(Err(e.into()));
+            }
+        }
+
+        let header = match fileformat::BlobHeader::parse_from_bytes(&buffer) {
+            Ok(header) => header,
+            Err(e) => {
+                self.offset = None;
+                self.last_blob_ok = false;
+                return Some(Err(new_protobuf_error(e, "blob header")));
+            }
+        };
+
+        self.offset = self.offset.map(|x| ByteOffset(x.0 + header_size));
+
+        Some(Ok(header))
+    }
+
+    async fn read_blob(&mut self) -> Option<Result<Blob>> {
+        let prev_offset = self.offset;
+
+        let header = match self.read_blob_header().await {
+            Some(Ok(header)) => header,
+            Some(Err(err)) => return Some(Err(err)),
+            None => return None,
+        };
+
+        let mut buffer = vec![0; header.datasize() as usize];
+        let read_result = self.reader.read_exact(&mut buffer).await;
+        match read_result {
+            Ok(read_byte_count) => {
+                if read_byte_count != header.datasize() as usize {
+                    return Some(Err(new_blob_error(BlobError::InvalidHeaderSize)));
+                }
+            }
+            Err(e) => {
+                return Some(Err(e.into()));
+            }
+        }
+
+        let blob = match fileformat::Blob::parse_from_bytes(&buffer) {
+            Ok(blob) => blob,
+            Err(e) => {
+                self.offset = None;
+                self.last_blob_ok = false;
+                return Some(Err(new_protobuf_error(e, "blob content")));
+            }
+        };
+
+        self.offset = self
+            .offset
+            .map(|x| ByteOffset(x.0 + header.datasize() as u64));
+
+        Some(Ok(Blob::new(header, blob, prev_offset)))
+    }
+
+    /// Creates a new stream of blobs.
+    ///
+    /// # Example
+    /// ```
+    /// use osmpbf::*;
+    /// use object_store::ObjectStoreExt;
+    /// use futures_util::StreamExt;
+    ///
+    /// # tokio_test::block_on(async {
+    /// // Setup AsyncBlobReader
+    /// let store = object_store::local::LocalFileSystem::new();
+    /// let path = std::path::Path::new("tests/test.osm.pbf");
+    /// let filesystem_path = object_store::path::Path::from_filesystem_path(path).unwrap();
+    /// let object_meta = store.head(&filesystem_path).await.unwrap();
+    /// let buf_reader = object_store::buffered::BufReader::new(std::sync::Arc::new(store), &object_meta);
+    /// let mut reader = AsyncBlobReader::new(buf_reader);
+    ///
+    /// // Create and pin stream to allow iteration
+    /// let stream = reader.stream();
+    /// futures_util::pin_mut!(stream);
+    ///
+    /// // Process stream of blobs
+    /// while let Some(Ok(blob)) = stream.next().await {
+    ///   // Decode and iterate over elements asynchronously
+    /// }
+    /// # })
+    /// ```
+    pub fn stream(&mut self) -> impl Stream<Item = Result<Blob>> + '_ {
+        stream! {
+            loop {
+                match self.read_blob().await {
+                    Some(Ok(blob_result)) => {
+                        yield Ok(blob_result);
+                    },
+                    Some(Err(error)) => {
+                        yield Err(error);
+                        break;
+                    }
+                    None => {
+                        break;
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,4 +1,8 @@
 use assert_approx_eq::assert_approx_eq;
+#[cfg(feature = "async")]
+use futures_util::TryStreamExt;
+#[cfg(feature = "async")]
+use object_store::ObjectStoreExt;
 use osmpbf::*;
 
 static REQ_SCHEMA_V6: &str = "OsmSchema-V0.6";
@@ -244,6 +248,34 @@ fn read_mmap_blobs() {
         } else {
             panic!("Unexpected blob type");
         }
+    }
+}
+
+#[tokio::test]
+#[cfg(feature = "async")]
+async fn read_blobs_async() {
+    for test_file in TEST_FILE_PATHS {
+        // Setup object store
+        let store = object_store::local::LocalFileSystem::new();
+        let path = std::path::Path::new(test_file.path);
+        let filesystem_path = object_store::path::Path::from_filesystem_path(path).unwrap();
+        let object_meta = store.head(&filesystem_path).await.unwrap();
+        let buf_reader =
+            object_store::buffered::BufReader::new(std::sync::Arc::new(store), &object_meta);
+
+        // Read blobs
+        let mut reader = AsyncBlobReader::new(buf_reader);
+        let blobs: Vec<Blob> = reader.stream().try_collect().await.unwrap();
+
+        assert_eq!(blobs.len(), 2);
+        assert_eq!(blobs[0].get_type(), BlobType::OsmHeader);
+        assert_eq!(blobs[1].get_type(), BlobType::OsmData);
+
+        let header = blobs[0].to_headerblock().unwrap();
+        check_header_block_content(&header, test_file);
+
+        let primitive_block = blobs[1].to_primitiveblock().unwrap();
+        check_primitive_block_content(&primitive_block);
     }
 }
 


### PR DESCRIPTION
As described in #47, adds support for async streaming of OSM PBFs. Using [`object_store`](https://docs.rs/object_store/latest/object_store/) as the input interface for flexibility - it supports most cloud providers, HTTP, and local files.

Example usage in docs and here: https://github.com/brad-richardson/osm-pbf-parquet/pull/15/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R116