### PR TITLE
Unify Node and DenseNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ parser features.
 A `PrimitiveBlock` contains an array of `PrimitiveGroup`s. Each `PrimitiveGroup`
 only contains one element type: `Node`, `Way`, `Relation` or `DenseNodes`. A
 `DenseNodes` item is an alternative and space-saving representation of a `Node`
-array. So, do not forget to check for `DenseNodes` when aggregating all nodes in
-a file.
+array, but this library will handle differences for you.
 
 Elements reference each other using integer IDs. Corresponding elements could be
 stored in any blob, so finding them can involve iterating over the whole file.

--- a/benches/counter_bench.rs
+++ b/benches/counter_bench.rs
@@ -25,7 +25,7 @@ fn bench_count(c: &mut Criterion) {
             reader
                 .par_map_reduce(
                     |element| match element {
-                        Element::Node(_) | Element::DenseNode(_) => (1, 0, 0),
+                        Element::Node(_) => (1, 0, 0),
                         Element::Way(_) => (0, 1, 0),
                         Element::Relation(_) => (0, 0, 1),
                     },

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -14,7 +14,7 @@ fn main() {
 
     match reader.par_map_reduce(
         |element| match element {
-            Element::Node(_) | Element::DenseNode(_) => (1, 0, 0),
+            Element::Node(_) => (1, 0, 0),
             Element::Way(_) => (0, 1, 0),
             Element::Relation(_) => (0, 0, 1),
         },

--- a/examples/indexed.rs
+++ b/examples/indexed.rs
@@ -25,7 +25,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             match element {
                 Element::Way(_way) => ways += 1,
                 Element::Node(_node) => nodes += 1,
-                Element::DenseNode(_dense_node) => nodes += 1,
                 Element::Relation(_) => {} // should not occur
             }
         },

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -118,21 +118,6 @@ impl<'a> DenseNodeIter<'a> {
             info_iter,
         }
     }
-
-    pub(crate) fn empty(block: &'a osmformat::PrimitiveBlock) -> DenseNodeIter<'a> {
-        DenseNodeIter {
-            block,
-            dids: [].iter(),
-            cid: 0,
-            dlats: [].iter(),
-            clat: 0,
-            dlons: [].iter(),
-            clon: 0,
-            keys_vals_slice: &[],
-            keys_vals_index: 0,
-            info_iter: None,
-        }
-    }
 }
 
 impl<'a> Iterator for DenseNodeIter<'a> {

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -26,6 +26,30 @@ pub enum Element<'a> {
     Relation(Relation<'a>),
 }
 
+impl<'a> From<Node<'a>> for Element<'a> {
+    fn from(n: Node<'a>) -> Self {
+        Element::Node(n)
+    }
+}
+
+impl<'a> From<DenseNode<'a>> for Element<'a> {
+    fn from(n: DenseNode<'a>) -> Self {
+        Element::DenseNode(n)
+    }
+}
+
+impl<'a> From<Way<'a>> for Element<'a> {
+    fn from(w: Way<'a>) -> Self {
+        Element::Way(w)
+    }
+}
+
+impl<'a> From<Relation<'a>> for Element<'a> {
+    fn from(r: Relation<'a>) -> Self {
+        Element::Relation(r)
+    }
+}
+
 /// An OpenStreetMap node element (See [OSM wiki](http://wiki.openstreetmap.org/wiki/Node)).
 #[derive(Clone, Debug)]
 pub struct Node<'a> {

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -195,9 +195,6 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
             for node in group.nodes() {
                 check_min_max(node.id(), &mut min_node_id, &mut max_node_id);
             }
-            for node in group.dense_nodes() {
-                check_min_max(node.id, &mut min_node_id, &mut max_node_id);
-            }
             for way in group.ways() {
                 check_min_max(way.id(), &mut min_way_id, &mut max_way_id);
             }
@@ -247,7 +244,6 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
     ///         match element {
     ///             Element::Way(way) => ways += 1,
     ///             Element::Node(node) => nodes += 1,
-    ///             Element::DenseNode(dense_node) => nodes += 1,
     ///             Element::Relation(_) => (), // should not occur
     ///         }
     ///     },
@@ -316,12 +312,6 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
                             element_callback(&Element::Node(node));
                         }
                     }
-                    for node in group.dense_nodes() {
-                        if node_ids.binary_search(&node.id).is_ok() {
-                            // ID found, return dense node
-                            element_callback(&Element::DenseNode(node));
-                        }
-                    }
                 }
             }
         }
@@ -348,7 +338,6 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
     ///     |element| {
     ///         match element {
     ///             Element::Node(node) => nodes += 1,
-    ///             Element::DenseNode(dense_node) => nodes += 1,
     ///             _ => {}
     ///         }
     ///     },
@@ -381,9 +370,6 @@ impl<R: Read + Seek + Send> IndexedReader<R> {
                 for group in block.groups() {
                     for node in group.nodes() {
                         f(Element::Node(node));
-                    }
-                    for dense_node in group.dense_nodes() {
-                        f(Element::DenseNode(dense_node));
                     }
                 }
             }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -49,7 +49,6 @@ static LOC_ON_WAYS_FILE_PATH: TestFile = TestFile {
 // Helper functions to simplify testing
 trait Getter {
     fn t_nodes(&self) -> Vec<Node>;
-    fn t_dense_nodes(&self) -> Vec<DenseNode>;
     fn t_ways(&self) -> Vec<Way>;
     fn t_relations(&self) -> Vec<Relation>;
 }
@@ -57,10 +56,6 @@ trait Getter {
 impl Getter for PrimitiveBlock {
     fn t_nodes(&self) -> Vec<Node> {
         self.groups().flat_map(|g| g.nodes()).collect()
-    }
-
-    fn t_dense_nodes(&self) -> Vec<DenseNode> {
-        self.groups().flat_map(|g| g.dense_nodes()).collect()
     }
 
     fn t_ways(&self) -> Vec<Way> {
@@ -136,41 +131,6 @@ fn check_primitive_block_content(block: &PrimitiveBlock) {
         assert!(nodes[0].info().visible());
         assert!(nodes[1].info().visible());
         assert!(nodes[2].info().visible());
-    }
-
-    let dense_nodes = block.t_dense_nodes();
-    if !dense_nodes.is_empty() {
-        assert_eq!(dense_nodes.len(), 3);
-
-        // node 1 lat
-        assert!(approx_eq(dense_nodes[1].lat(), 52.11992359584));
-        assert_eq!(dense_nodes[1].nano_lat(), 52119923500);
-        assert_eq!(dense_nodes[1].decimicro_lat(), 521199235);
-        //node 1 lon
-        assert!(approx_eq(dense_nodes[1].lon(), 11.62564468943));
-        assert_eq!(dense_nodes[1].nano_lon(), 11625644600);
-        assert_eq!(dense_nodes[1].decimicro_lon(), 116256446);
-
-        //node 2 lat
-        assert!(approx_eq(dense_nodes[2].lat(), 52.11989910567));
-        assert_eq!(dense_nodes[2].nano_lat(), 52119899100);
-        assert_eq!(dense_nodes[2].decimicro_lat(), 521198991);
-        // node 2 lon
-        assert!(approx_eq(dense_nodes[2].lon(), 11.63101926915));
-        assert_eq!(dense_nodes[2].nano_lon(), 11631019200);
-        assert_eq!(dense_nodes[2].decimicro_lon(), 116310192);
-
-        assert_eq!(dense_nodes[0].id, 105);
-        assert_eq!(dense_nodes[1].id, 106);
-        assert_eq!(dense_nodes[2].id, 108);
-
-        assert_eq!(dense_nodes[0].info().map(|x| x.uid()), Some(17));
-        assert_eq!(dense_nodes[1].info().map(|x| x.uid()), Some(17));
-        assert_eq!(dense_nodes[2].info().map(|x| x.uid()), Some(17));
-
-        assert_eq!(dense_nodes[0].info().map(|x| x.visible()), Some(true));
-        assert_eq!(dense_nodes[1].info().map(|x| x.visible()), Some(true));
-        assert_eq!(dense_nodes[2].info().map(|x| x.visible()), Some(true));
     }
 
     {
@@ -306,7 +266,6 @@ fn read_ways_and_deps() {
                     match element {
                         Element::Way(_) => ways += 1,
                         Element::Node(_) => nodes += 1,
-                        Element::DenseNode(_) => nodes += 1,
                         Element::Relation(_) => panic!(), // should not occur
                     }
                 },
@@ -331,12 +290,12 @@ fn read_history_file() {
     check_header_block_content(&header, &HISTORY_FILE_PATH);
 
     let primitive_block = blobs[1].to_primitiveblock().unwrap();
-    let nodes = primitive_block.t_dense_nodes();
+    let nodes = primitive_block.t_nodes();
 
     assert_eq!(nodes.len(), 2);
 
-    assert!(!nodes[0].info().unwrap().visible());
-    assert!(nodes[1].info().unwrap().visible());
+    assert!(!nodes[0].info().visible());
+    assert!(nodes[1].info().visible());
 }
 
 #[test]
@@ -354,7 +313,6 @@ fn read_loc_on_ways_file() {
 
     {
         let primitive_block = blobs[1].to_primitiveblock().unwrap();
-        assert_eq!(primitive_block.t_dense_nodes().len(), 0);
         assert_eq!(primitive_block.t_relations().len(), 0);
         let ways = primitive_block.t_ways();
         assert_eq!(ways.len(), 1);
@@ -404,7 +362,6 @@ fn read_loc_on_ways_file() {
 
     {
         let primitive_block = blobs[2].to_primitiveblock().unwrap();
-        assert_eq!(primitive_block.t_dense_nodes().len(), 0);
         assert_eq!(primitive_block.t_ways().len(), 0);
 
         let relations = primitive_block.t_relations();


### PR DESCRIPTION
Abstract over the differences between Nodes and DenseNodes.

The benchmarks don't appear to be working and I don't have any experience with benchmarking tools in rust but I made a simple program that counts all the postboxes in planet.pbf. On my PC it took 181 seconds to run using the old version and 188 seconds using my new version which is a 4% slowdown. For me, the simplicity of not having to write every piece of code to handle Nodes and DenseNodes separately would definitely be worth it, but it is a tradeoff.

See also issue 41 (@nyurik )