### PR TITLE
Update lib.rs to allow access to `proto` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,6 @@ pub mod indexed;
 pub mod mmap_blob;
 pub mod reader;
 
-mod proto {
+pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 }


### PR DESCRIPTION
this change allows crate users to programmatically access the generated proto files (which can be useful during the creation of mock pbf files, for example)