### PR TITLE
Use protobuf zero-copy deserialisation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ zlib-ng = ["flate2/zlib-ng"]
 
 [dependencies]
 byteorder = "1.4"
+bytes = "1.10.1"
 flate2 = { version = "1.0", default-features = false }
 memmap2 = "0.5"
-protobuf = "3.1"
+protobuf = { version = "3.1", features = ["with-bytes"] }
 rayon = "1.5"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -16,11 +16,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let out_dir = std::env::var("OUT_DIR")?;
 
+    let customizations = protobuf_codegen::Customize::default()
+        .tokio_bytes(true)
+        .tokio_bytes_for_string(true)
+        .lite_runtime(true);
+
     protobuf_codegen::Codegen::new()
         .pure()
         .out_dir(&out_dir)
         .inputs(proto_files)
         .include("src/proto")
+        .customize(customizations)
         .run()?;
 
     std::fs::File::create(out_dir + "/mod.rs")?.write_all(MOD_RS)?;

--- a/src/block.rs
+++ b/src/block.rs
@@ -29,12 +29,12 @@ impl HeaderBlock {
 
     /// Returns a list of required features that a parser needs to implement to parse the following
     /// [`PrimitiveBlock`]s.
-    pub fn required_features(&self) -> &[String] {
+    pub fn required_features(&self) -> &[protobuf::Chars] {
         self.header.required_features.as_slice()
     }
 
     /// Returns a list of optional features that a parser can choose to ignore.
-    pub fn optional_features(&self) -> &[String] {
+    pub fn optional_features(&self) -> &[protobuf::Chars] {
         self.header.optional_features.as_slice()
     }
 
@@ -145,7 +145,7 @@ impl PrimitiveBlock {
     /// themselves; instead, they just store indices to the stringtable. By convention, the
     /// contained strings are UTF-8 encoded but it is not safe to assume that (use
     /// `std::str::from_utf8`).
-    pub fn raw_stringtable(&self) -> &[Vec<u8>] {
+    pub fn raw_stringtable(&self) -> &[bytes::Bytes] {
         self.block.stringtable.s.as_slice()
     }
 }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -125,7 +125,7 @@ impl<'a> Node<'a> {
     /// themselves; instead, they just store indices to a common stringtable. By convention, the
     /// contained strings are UTF-8 encoded but it is not safe to assume that (use
     /// `std::str::from_utf8`).
-    pub fn raw_stringtable(&self) -> &[Vec<u8>] {
+    pub fn raw_stringtable(&self) -> &[bytes::Bytes] {
         self.block.stringtable.s.as_slice()
     }
 }
@@ -235,7 +235,7 @@ impl<'a> Way<'a> {
     /// themselves; instead, they just store indices to a common stringtable. By convention, the
     /// contained strings are UTF-8 encoded but it is not safe to assume that (use
     /// `std::str::from_utf8`).
-    pub fn raw_stringtable(&self) -> &[Vec<u8>] {
+    pub fn raw_stringtable(&self) -> &[bytes::Bytes] {
         self.block.stringtable.s.as_slice()
     }
 }
@@ -315,7 +315,7 @@ impl<'a> Relation<'a> {
     /// themselves; instead, they just store indices to a common stringtable. By convention, the
     /// contained strings are UTF-8 encoded but it is not safe to assume that (use
     /// `std::str::from_utf8`).
-    pub fn raw_stringtable(&self) -> &[Vec<u8>] {
+    pub fn raw_stringtable(&self) -> &[bytes::Bytes] {
         self.block.stringtable.s.as_slice()
     }
 }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -77,12 +77,12 @@ fn approx_eq(a: f64, b: f64) -> bool {
 }
 
 /// Ensure two vectors have the same values, ignoring their order
-fn is_same_unordered(a: &[&str], b: &[String]) -> bool {
+fn is_same_unordered(a: &[&str], b: &[protobuf::Chars]) -> bool {
     let mut a = a.to_vec();
     let mut b = b.to_vec();
     a.sort_unstable();
     b.sort_unstable();
-    a == b
+    a.iter().zip(b).all(|(a, b)| *a == &*b)
 }
 
 // Compare the content of a HeaderBlock with known values from the test file.
@@ -225,7 +225,7 @@ fn read_blobs() {
 fn read_mmap_blobs() {
     for test_file in TEST_FILE_PATHS {
         let mmap = unsafe { Mmap::from_path(test_file.path).unwrap() };
-        let reader = MmapBlobReader::new(&mmap);
+        let reader = MmapBlobReader::new(mmap);
 
         let blobs = reader.collect::<Result<Vec<_>>>().unwrap();
 


### PR DESCRIPTION
This enables the `with-bytes` feature of protobuf, and enables it via protobuf-codegen, in order to reduce allocations and memory copying by using the `Bytes` library. This means that when possible `string` and `bytes` fields in the protobuf are referring to the original protobuf data, instead of making many small allocations for each piece of data.

The upsides are:
- Improved runtime performance, due to less heap allocations and memory copying.

The downsides of this are:
- Slightly increased complexity when using the library, as the user has to learn how to use `Bytes` and `protobuf::Chars`.
- Possible increased average memory usage, as cloning a single element from the stringtable will keep the entire block alive.

I have measured a 5-10% performance uplift with the included benchmark, but my machine (overheating laptop) is not super reliable so benchmarking should be done on a stable machine.